### PR TITLE
Options page

### DIFF
--- a/admin/class-audience-config.php
+++ b/admin/class-audience-config.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * Holds configuration items for the
+ * audience custom taxonomy.
+ */
+if ( ! class_exists( 'UCF_Audience_Config' ) ) {
+	/**
+	 * Class that handles the configuration
+	 * of the Audience taxonomy
+	 * @author Jim Barnes
+	 * @since 1.0.0
+	 */
+	class UCF_Audience_Config {
+		public static
+			/**
+			 * @var string The option prefix used.
+			 */
+			$options_prefix  = 'ucf_aud_',
+			/**
+			 * @var array The defaults array
+			 */
+			$option_defaults = array(
+				'post_types'   => array()
+			);
+
+		/**
+		 * Creates options via the WP Options API that are utilized by the
+		 * plugin. Intended to be run on plugin activation.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function add_options() {
+			$defaults = self::$option_defaults;
+
+			add_option( self::$options_prefix . 'post_types', $defaults['post_types'] );
+		}
+
+		/**
+		 * Deletes options via the WP Options API that are utilized by the
+		 * plugin. Intended to be run on plugin uninstallation.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function delete_options() {
+			delete_option( self::$options_prefix . 'post_types' );
+		}
+
+		/**
+		 * Returns a list of default plugin options. Applied any overridden
+		 * default values set within the options page.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return array
+		 */
+		public static function get_option_defaults() {
+			$defaults = self::$option_defaults;
+
+			$configurable_defaults = array(
+				'post_types'   => get_option( self::$options_prefix . 'post_types', $defaults['post_types'] )
+			);
+
+			$configurable_defaults = self::format_options( $configurable_defaults );
+
+			$defaults = array_merge( $defaults, $configurable_defaults );
+
+			return $defaults;
+		}
+
+		/**
+		 * Returns an array with plugin defaults applied
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param array $list The list of options to apply defaults to
+		 * @param boolean $list_keys_only Modifies results to only return array key
+		 * 								  values present in $list.
+		 * @return array
+		 */
+		public static function apply_option_defaults( $list, $list_keys_only=false ) {
+			$defaults = self::get_option_defaults();
+			$options = array();
+			if ( $list_keys_only ) {
+				foreach( $list as $key => $val ) {
+					$options[$key] = ! empty( $val ) ? $val : $defaults[$key];
+				}
+			} else {
+				$options = array_merge( $defaults, $list );
+			}
+			return $options;
+		}
+
+		/**
+		 * Performs typecasting and sanitization on an array of plugin options.
+		 * @author Jim Barnes
+		 * @param array $list The list of options to format.
+		 * @return array
+		 */
+		public static function format_options( $list ) {
+			foreach( $list as $key => $val ) {
+				switch( $key ) {
+					default:
+						break;
+				}
+			}
+			return $list;
+		}
+
+		/**
+		 * Applies formatting to a single options. Intended to be passed to the
+		 * option_{$option} hook.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param mixed $value The value to be formatted
+		 * @param string $option_name The name of the option being formatted.
+		 * @return mixed
+		 */
+		public static function format_option( $value, $option_name ) {
+			$option_name_no_prefix = str_replace( self::$options_prefix, '', $option_name );
+			$option_formatted = self::$format_options( array( $option_name_no_prefix => $value ) );
+			return $option_formatted;
+		}
+
+		/**
+		 * Adds filters for plugin options that apply
+		 * our formatting rules to option values.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function add_option_formatting_filters() {
+			$defaults = self::$option_defaults;
+			foreach( $defaults as $option => $default ) {
+				$option_name = self::$options_prefix . $option;
+				add_filter( "option_{$option_name}", array( 'WPIS_Config', 'format_option' ), 10, 2 );
+			}
+		}
+
+		/**
+		 * Utility method for returning an option from the WP Options API
+		 * or a plugin option default.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param string $option_name The name of the option to retrieve.
+		 * @return mixed
+		 */
+		public static function get_option_or_default( $option_name ) {
+			$option_name_no_prefix = str_replace( self::$options_prefix, '', $option_name );
+			$option_name = self::$options_prefix . $option_name_no_prefix;
+			$option = get_option( $option_name );
+			$option_formatted = self::apply_option_defaults( array(
+				$option_name_no_prefix => $option
+			), true );
+			return $option_formatted[$option_name_no_prefix];
+		}
+
+		/**
+		 * Initializes setting registration with the Settings API.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function settings_init() {
+			$settings_slug = 'ucf_aud_settings';
+			$defaults      = self::$option_defaults;
+			$display_fn    = array( 'UCF_Audience_Config', 'display_settings_field' );
+
+			// Register all default settings.
+			foreach( $defaults as $key => $val ) {
+				register_setting(
+					$settings_slug,
+					self::$options_prefix . $key
+				);
+			}
+
+			add_settings_section(
+				'ucf_aud_taxonomy',
+				'Taxonomy Settings',
+				'',
+				$settings_slug
+			);
+
+			$post_type_options = get_post_types(
+				array(
+					'public'   => true,
+					'_builtin' => true
+				),
+				'objects'
+			);
+
+			$post_type_options = array_filter( array_map( function( $post_type ) {
+				return $post_type->label;
+			}, $post_type_options ), function( $key ) {
+				return ( $key !== 'attachment' );
+			}, ARRAY_FILTER_USE_KEY );
+
+			add_settings_field(
+				self::$options_prefix . 'post_types',
+				'Assign To Post Types',
+				$display_fn,
+				$settings_slug,
+				'ucf_aud_taxonomy',
+				array(
+					'label_for'   => self::$options_prefix . 'post_types',
+					'description' => 'Check each post type the Audience taxonomy should be assigned to.',
+					'type'        => 'checkbox-list',
+					'options'     => $post_type_options
+				)
+			);
+		}
+
+		/**
+		 * Displays an individual settings's field markup.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param array The field's argument array
+		 * @return string The formatted html of the field
+		 */
+		public static function display_settings_field( $args ) {
+			$option_name = $args['label_for'];
+			$description = $args['description'];
+			$field_type  = $args['type'];
+			$options     = isset( $args['options'] ) ? $args['options'] : null;
+			$current_val = self::get_option_or_default( $option_name );
+			$markup      = '';
+
+			switch( $field_type ) {
+				case 'checkbox':
+					ob_start();
+				?>
+					<input type="checkbox" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>"<?php echo ( $current_val === true ) ? ' checked' : ''; ?>>
+					<p class="description">
+						<?php echo $description; ?>
+					</p>
+				<?php
+					$markup = ob_get_clean();
+					break;
+				case 'checkbox-list':
+					ob_start();
+					if ( ! empty( $options ) ) :
+				?>
+					<p class="description"><strong><?php echo $description; ?></strong></p>
+					<ul class="catagorychecklist">
+				<?php
+						foreach( $options as $val => $text ) :
+				?>
+					<li>
+						<label for="<?php echo $option_name . '_' . $val; ?>">
+						<input type="checkbox" id="<?php echo $option_name . '_' . $val; ?>" name="<?php echo $option_name; ?>[]"<?php echo ( in_array( $val, $current_val ) ) ? ' checked' : ''; ?> value="<?php echo $val; ?>">
+							<?php echo $text; ?>
+						</label>
+					</li>
+				<?php
+						endforeach;
+				?>
+					</ul>
+				<?php
+					else:
+				?>
+					<p class="description" style="color: red;">
+						There was an error loading the options.
+					</p>
+				<?php
+					endif;
+					$markup = ob_get_clean();
+					break;
+				case 'number':
+				case 'date':
+				case 'email':
+				case 'month':
+				case 'tel':
+				case 'text':
+				case 'text':
+				case 'time':
+				case 'url':
+					ob_start();
+				?>
+					<input type="<?php echo $field_type; ?>" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>" value="<?php echo $current_val; ?>">
+					<p class="description">
+						<?php echo $description; ?>
+					</p>
+				<?php
+					$markup = ob_get_clean();
+					break;
+				default:
+				?>
+					<input type="text" id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>" value="<?php echo $current_val; ?>">
+					<p class="description">
+						<?php echo $description; ?>
+					</p>
+				<?php
+					$markup = ob_get_clean();
+					break;
+			}
+
+			echo $markup;
+		}
+
+		/**
+		 * Registers the settings page to display in the WordPress admin.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return string The resulting page's hook suffix.
+		 */
+		public static function add_options_page() {
+			$page_title = 'UCF Audience Taxonomy Settings';
+			$menu_title = 'UCF Audience Taxonomy';
+			$capability = 'manage_options';
+			$menu_slug  = 'ucf_aud_settings';
+			$callback   = array( 'UCF_Audience_Config', 'options_page_html' );
+
+			return add_options_page(
+				$page_title,
+				$menu_title,
+				$capability,
+				$menu_slug,
+				$callback
+			);
+		}
+
+		public static function options_page_html() {
+			ob_start();
+		?>
+			<div class="wrap">
+				<h1><?php echo get_admin_page_title(); ?></h1>
+				<form method="post" action="options.php">
+					<?php
+						settings_fields( 'ucf_aud_settings' );
+						do_settings_sections( 'ucf_aud_settings' );
+						submit_button();
+					?>
+				</form>
+			</div>
+		<?php
+			echo ob_get_clean();
+		}
+	}
+}

--- a/includes/class-audience-taxonomy.php
+++ b/includes/class-audience-taxonomy.php
@@ -59,6 +59,10 @@ if ( ! class_exists( 'UCF_Audience_Taxonomy' ) ) {
 				self::$post_type_defaults
 			);
 
+			$settings_post_types = UCF_Audience_Config::get_option_or_default( 'post_types' );
+
+			$post_types = array_merge( $post_types, $settings_post_types );
+
 			register_taxonomy( 'audience', $post_types, self::args( $labels ) );
 		}
 

--- a/ucf-audience-tax.php
+++ b/ucf-audience-tax.php
@@ -14,6 +14,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 define( 'UCF_AUDIENCE__FILE', __FILE__ );
 
+require_once 'admin/class-audience-config.php';
 require_once 'includes/class-audience-taxonomy.php';
 
 if ( ! function_exists( 'ucf_audience_activation' ) ) {
@@ -24,6 +25,7 @@ if ( ! function_exists( 'ucf_audience_activation' ) ) {
 	 * @return void
 	 */
 	function ucf_audience_activation() {
+		UCF_Audience_Config::add_options();
 		UCF_Audience_Taxonomy::register();
 		flush_rewrite_rules();
 	}
@@ -39,6 +41,7 @@ if ( ! function_exists( 'ucf_audience_deactivation' ) ) {
 	 * @return void
 	 */
 	function ucf_audience_deactivation() {
+		UCF_Audience_Config::delete_options();
 		flush_rewrite_rules();
 	}
 }
@@ -51,6 +54,10 @@ if ( ! function_exists( 'ucf_audience_init' ) ) {
 	 * @return void
 	 */
 	function ucf_audience_init() {
+		// Add admin menu item
+		add_action( 'admin_init', array( 'UCF_Audience_Config', 'settings_init' ) );
+		add_action( 'admin_menu', array( 'UCF_Audience_Config', 'add_options_page' ) );
+
 		add_action( 'init', array( 'UCF_Audience_Taxonomy', 'register' ), 10, 0 );
 	}
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Audience-Tax-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Audience-Tax-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds an options page and the post_types option, which allows the taxonomy to be registered to a post type through the settings screen.

**Motivation and Context**
This should make it easier to mark particular post types as intended for a particular audience or not without requiring a theme change to add it to the post_types filter.

**How Has This Been Tested?**
Change has been tested locally and will be in DEV as soon as the jobs are created.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
